### PR TITLE
convert to/from faiss

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'nanopq'
-copyright = '2018, Yusuke Matsui'
+copyright = '2019, Yusuke Matsui'
 author = 'Yusuke Matsui'
 
 # The short X.Y version

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -28,3 +28,9 @@ Optimized Product Quantization (OPQ)
     :members:
     :undoc-members:
 
+
+Convert Functions to/from Faiss
+-------------------------------
+
+.. autofunction:: nanopq.nanopq_to_faiss
+.. autofunction:: nanopq.faiss_to_nanopq

--- a/nanopq/__init__.py
+++ b/nanopq/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ['PQ', 'OPQ', 'DistanceTable']
+__all__ = ['PQ', 'OPQ', 'DistanceTable', 'nanopq_to_faiss', 'faiss_to_nanopq']
 __version__ = '0.1.7.dev1'
 
 from .pq import PQ, DistanceTable
 from .opq import OPQ
+from .convert_faiss import nanopq_to_faiss, faiss_to_nanopq

--- a/nanopq/__init__.py
+++ b/nanopq/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['PQ', 'OPQ', 'DistanceTable', 'nanopq_to_faiss', 'faiss_to_nanopq']
-__version__ = '0.1.7.dev1'
+__version__ = '0.1.7'
 
 from .pq import PQ, DistanceTable
 from .opq import OPQ

--- a/nanopq/convert_faiss.py
+++ b/nanopq/convert_faiss.py
@@ -1,0 +1,69 @@
+# Try to import faiss
+import importlib
+spec = importlib.util.find_spec("faiss")
+if spec is None:
+    raise ImportError("Cannot find the faiss module.")
+else:
+    import faiss
+
+from .pq import PQ
+import numpy as np
+
+
+def nanopq_to_faiss(pq_nanopq):
+    """Convert a :class:`nanopq.PQ` instance to `faiss.IndexPQ <https://github.com/facebookresearch/faiss/blob/master/IndexPQ.h>`_.
+
+    Args:
+        pq_nanopq (nanopq.PQ): An input PQ instance.
+
+    Returns:
+        faiss.IndexPQ: A converted PQ instance, with the same codewords to the input.
+
+    """
+    assert isinstance(pq_nanopq, PQ), "Error. pq_nanopq must be nanopq.pq"
+    assert pq_nanopq.codewords is not None, "Error. pq_nanopq.codewords must have been set beforehand"
+    D = pq_nanopq.Ds * pq_nanopq.M
+    nbits = {np.uint8: 8, np.uint16: 16, np.uint32: 32}[pq_nanopq.code_dtype]
+
+    pq_faiss = faiss.IndexPQ(D, pq_nanopq.M, nbits)
+
+    for m in range(pq_nanopq.M):
+        # Prepare std::vector<float>
+        codewords_cpp_m = faiss.FloatVector()
+
+        # Flatten m-th codewords from (Ks, Ds) to (Ks * Ds, ), then copy them to cpp
+        faiss.copy_array_to_vector(pq_nanopq.codewords[m].reshape(-1), codewords_cpp_m)
+
+        # Set the codeword to ProductQuantizer in IndexPQ
+        pq_faiss.pq.set_params(centroids=codewords_cpp_m.data(), m=m)
+
+    pq_faiss.is_trained = True
+
+    return pq_faiss
+
+
+def faiss_to_nanopq(pq_faiss):
+    """Convert a `faiss.IndexPQ <https://github.com/facebookresearch/faiss/blob/master/IndexPQ.h>`_ instance to :class:`nanopq.PQ`.
+
+    Args:
+        pq_faiss (faiss.IndexPQ): An input PQ instance.
+
+    Returns:
+        tuple:
+            * nanopq.PQ: A converted PQ instance, with the same codewords to the input.
+            * np.ndarray: Stored PQ codes in the input IndexPQ, with the shape=(N, M). This will be empty if codes are not stored
+
+    """
+    assert isinstance(pq_faiss, faiss.swigfaiss.IndexPQ), "Error. pq_faiss must be IndexPQ"
+    assert pq_faiss.is_trained, "Error. pq_faiss must have been trained"
+
+    pq_nanopq = PQ(M=pq_faiss.pq.M, Ks=int(2**pq_faiss.pq.nbits))
+    pq_nanopq.Ds = int(pq_faiss.pq.d / pq_faiss.pq.M)
+
+    # Extract codewords from pq_IndexPQ.ProductQuantizer, reshape them to M*Ks*Ds
+    codewords = faiss.vector_to_array(pq_faiss.pq.centroids).reshape(
+        pq_nanopq.M, pq_nanopq.Ks, pq_nanopq.Ds)
+
+    pq_nanopq.codewords = codewords
+
+    return pq_nanopq, faiss.vector_to_array(pq_faiss.codes).reshape(-1, pq_faiss.pq.M)

--- a/nanopq/convert_faiss.py
+++ b/nanopq/convert_faiss.py
@@ -2,7 +2,7 @@
 import importlib
 spec = importlib.util.find_spec("faiss")
 if spec is None:
-    raise ImportError("Cannot find the faiss module.")
+    pass  # If faiss hasn't been installed. Just skip
 else:
     import faiss
 
@@ -12,6 +12,7 @@ import numpy as np
 
 def nanopq_to_faiss(pq_nanopq):
     """Convert a :class:`nanopq.PQ` instance to `faiss.IndexPQ <https://github.com/facebookresearch/faiss/blob/master/IndexPQ.h>`_.
+    To use this function, `faiss module needs to be installed <https://github.com/facebookresearch/faiss/blob/master/INSTALL.md>`_.
 
     Args:
         pq_nanopq (nanopq.PQ): An input PQ instance.
@@ -44,6 +45,7 @@ def nanopq_to_faiss(pq_nanopq):
 
 def faiss_to_nanopq(pq_faiss):
     """Convert a `faiss.IndexPQ <https://github.com/facebookresearch/faiss/blob/master/IndexPQ.h>`_ instance to :class:`nanopq.PQ`.
+    To use this function, `faiss module needs to be installed <https://github.com/facebookresearch/faiss/blob/master/INSTALL.md>`_.
 
     Args:
         pq_faiss (faiss.IndexPQ): An input PQ instance.

--- a/tests/test_convert_faiss.py
+++ b/tests/test_convert_faiss.py
@@ -1,0 +1,107 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent))
+import nanopq
+
+import unittest
+import numpy as np
+
+import importlib
+spec = importlib.util.find_spec("faiss")
+if spec is None:
+    raise unittest.SkipTest("Cannot find the faiss module. Skipt the test for convert_faiss")
+else:
+    import faiss
+    print("faiss version:", faiss.__version__)
+
+
+class TestSuite(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+
+    def test_nanopq_to_faiss(self):
+        D, M, Ks = 32, 4, 256
+        Nt, Nb, Nq = 2000, 10000, 100
+        Xt = np.random.rand(Nt, D).astype(np.float32)
+        Xb = np.random.rand(Nb, D).astype(np.float32)
+        Xq = np.random.rand(Nq, D).astype(np.float32)
+        pq_nanopq = nanopq.PQ(M=M, Ks=Ks)
+        pq_nanopq.fit(vecs=Xt)
+
+        with self.assertRaises(AssertionError):  # opq is not supported
+            opq = nanopq.OPQ(M=M, Ks=Ks)
+            nanopq.nanopq_to_faiss(opq)
+
+        pq_faiss = nanopq.nanopq_to_faiss(pq_nanopq)  # IndexPQ
+
+        # Encoded results should be same
+        Cb_nanopq = pq_nanopq.encode(vecs=Xb)
+        Cb_faiss = pq_faiss.pq.compute_codes(x=Xb)   # ProductQuantizer in IndexPQ
+        self.assertTrue(np.array_equal(Cb_nanopq, Cb_faiss))
+
+        # Search result should be same
+        topk = 100
+        pq_faiss.add(Xb)
+        _, ids1 = pq_faiss.search(x=Xq, k=topk)
+        ids2 = np.array([np.argsort(pq_nanopq.dtable(query=xq).adist(codes=Cb_nanopq))[:topk] for xq in Xq])
+        self.assertTrue(np.array_equal(ids1, ids2))
+
+    def test_faiss_to_nanopq(self):
+        D, M, Ks = 32, 4, 256
+        Nt, Nb, Nq = 2000, 10000, 100
+        nbits = int(np.log2(Ks))
+        assert nbits == 8
+        Xt = np.random.rand(Nt, D).astype(np.float32)
+        Xb = np.random.rand(Nb, D).astype(np.float32)
+        Xq = np.random.rand(Nq, D).astype(np.float32)
+
+        pq_faiss = faiss.IndexPQ(D, M, nbits)
+        pq_faiss.train(x=Xt)
+        pq_faiss.add(x=Xb)
+
+        pq_nanopq, Cb_faiss = nanopq.faiss_to_nanopq(pq_faiss=pq_faiss)
+        self.assertEqual(pq_nanopq.codewords.shape, (M, Ks, int(D / M)))
+
+        # Encoded results should be same
+        Cb_nanopq = pq_nanopq.encode(vecs=Xb)
+        self.assertTrue(np.array_equal(Cb_nanopq, Cb_faiss))
+
+        # Search result should be same
+        topk = 100
+        _, ids1 = pq_faiss.search(x=Xq, k=topk)
+        ids2 = np.array([np.argsort(pq_nanopq.dtable(query=xq).adist(codes=Cb_nanopq))[:topk] for xq in Xq])
+        self.assertTrue(np.array_equal(ids1, ids2))
+
+    def test_faiss_nanopq_compare_accuracy(self):
+        D, M, Ks = 32, 4, 256
+        Nt, Nb, Nq = 20000, 10000, 100
+        nbits = int(np.log2(Ks))
+        assert nbits == 8
+        Xt = np.random.rand(Nt, D).astype(np.float32)
+        Xb = np.random.rand(Nb, D).astype(np.float32)
+        Xq = np.random.rand(Nq, D).astype(np.float32)
+
+        pq_faiss = faiss.IndexPQ(D, M, nbits)
+        pq_faiss.train(x=Xt)
+        Cb_faiss = pq_faiss.pq.compute_codes(Xb)
+        Xb_faiss_ = pq_faiss.pq.decode(Cb_faiss)
+
+        pq_nanopq = nanopq.PQ(M=M, Ks=Ks)
+        pq_nanopq.fit(vecs=Xt)
+        Cb_nanopq = pq_nanopq.encode(vecs=Xb)
+        Xb_nanopq_ = pq_nanopq.decode(codes=Cb_nanopq)
+
+        # Reconstruction error should be almost identical
+        avg_relative_error_faiss = ((Xb - Xb_faiss_) ** 2).sum() / (Xb ** 2).sum()
+        avg_relative_error_nanopq = ((Xb - Xb_nanopq_) ** 2).sum() / (Xb ** 2).sum()
+        diff_rel = (avg_relative_error_faiss - avg_relative_error_nanopq)/ avg_relative_error_faiss
+        diff_rel = np.sqrt(diff_rel ** 2)
+        print("avg_rel_error_faiss:", avg_relative_error_faiss)
+        print("avg_rel_error_nanopq:", avg_relative_error_nanopq)
+        print("diff rel:", diff_rel)
+
+        self.assertLess(diff_rel, 0.01)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Functions to convert a PQ instance of nanopq (`nanopq.PQ`) to/from that of faiss (`faiss.IndexPQ`): 
`nanopq.nanopq_to_faiss` and `nanopq.faiss_to_nanopq`