### PR TITLE
Import importlib.util

### DIFF
--- a/nanopq/convert_faiss.py
+++ b/nanopq/convert_faiss.py
@@ -1,5 +1,5 @@
 # Try to import faiss
-import importlib
+import importlib.util
 spec = importlib.util.find_spec("faiss")
 if spec is None:
     pass  # If faiss hasn't been installed. Just skip

--- a/tests/test_convert_faiss.py
+++ b/tests/test_convert_faiss.py
@@ -6,7 +6,7 @@ import nanopq
 import unittest
 import numpy as np
 
-import importlib
+import importlib.util
 spec = importlib.util.find_spec("faiss")
 if spec is None:
     raise unittest.SkipTest("Cannot find the faiss module. Skipt the test for convert_faiss")


### PR DESCRIPTION
I cannot import `nanopq`.

```bash
$ python -c "import nanopq"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/my/python3.6/site-packages/nanopq/__init__.py", line 6, in <module>
    from .convert_faiss import nanopq_to_faiss, faiss_to_nanopq
  File "/my/python3.6/site-packages/nanopq/convert_faiss.py", line 3, in <module>
    spec = importlib.util.find_spec("faiss")
AttributeError: module 'importlib' has no attribute 'util'
```

It looks like this.

```bash
python -c "import importlib; importlib.util"  # error
# ↓
python -c "import importlib.util; importlib.util"  # no error
```

Your project's CI uses `pytest`, and `pytest` contains meny `import importlib.util`.
https://github.com/pytest-dev/pytest/search?q=importlib&unscoped_q=importlib
So, maybe an error does not occur at CI test.