### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}    # to activate conda
       run: |
+        conda install numpy  # because of faiss, we need to use numpy of conda (not pip)
         pip install pytest
         python setup.py install
         conda install -c pytorch faiss-cpu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         elif [ "${{ matrix.os }}" = "macos-latest" ]; then
           conda install -c pytorch faiss-cpu==1.7.3
         elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-          conda install -c pytorch faiss-cpu==1.7.2
+          conda install -c pytorch faiss-cpu==1.7.4
         fi
         
     - name: Test with pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,7 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        # conda install -c pytorch faiss-cpu
-        conda install -c conda-forge faiss-cpu
+        conda install -c pytorch faiss-cpu=1.7.3
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        conda install -c pytorch faiss-cpu=1.7.3
+        # conda install -c pytorch faiss-cpu
+        conda install -c conda-forge faiss-cpu
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,16 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        conda install -c pytorch "faiss-cpu<1.7.4"   # After the bug of 1.7.4 is fixed, let's use the latest version
+        #conda install -c pytorch faiss-cpu
+
+        # After the bug of 1.7.4 is fixed, let's use the latest version. As of now, install the old version for each os.
+        if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+          conda install -c pytorch faiss-cpu==1.7.3
+        elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+          conda install -c pytorch faiss-cpu==1.7.3
+        elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+          conda install -c pytorch faiss-cpu==1.7.2
+        fi
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,16 +27,7 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        conda install -c pytorch "faiss-cpu<1.7.4"
-
-        # # After the bug of 1.7.4 is fixed, let's use the latest version. As of now, install the old version for each os.
-        # if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-        #   conda install -c pytorch faiss-cpu==1.7.3
-        # elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-        #   conda install -c pytorch faiss-cpu==1.7.3
-        # elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-        #   conda install -c pytorch faiss-cpu==1.7.2
-        # fi
+        conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        conda install -c pytorch faiss-cpu<1.7.4   # After the bug of 1.7.4 is fixed, let's use the latest version
+        conda install -c pytorch "faiss-cpu<1.7.4"   # After the bug of 1.7.4 is fixed, let's use the latest version
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        conda install -c pytorch faiss-cpu=1.7.3
+        conda install -c pytorch faiss-cpu<1.7.4   # After the bug of 1.7.4 is fixed, let's use the latest version
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,9 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}    # to activate conda
       run: |
-        conda install numpy  # because of faiss, we need to use numpy of conda (not pip)
         pip install pytest
         python setup.py install
-        conda install -c pytorch faiss-cpu
+        conda install -c pytorch faiss-cpu=1.7.3
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
+        python-version: [3.8]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
 
     steps:
     - name: Checkout
@@ -27,16 +27,16 @@ jobs:
       run: |
         pip install pytest
         python setup.py install
-        #conda install -c pytorch faiss-cpu
+        conda install -c pytorch "faiss-cpu<1.7.4"
 
-        # After the bug of 1.7.4 is fixed, let's use the latest version. As of now, install the old version for each os.
-        if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-          conda install -c pytorch faiss-cpu==1.7.3
-        elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-          conda install -c pytorch faiss-cpu==1.7.3
-        elif [ "${{ matrix.os }}" = "windows-latest" ]; then
-          conda install -c pytorch faiss-cpu==1.7.4
-        fi
+        # # After the bug of 1.7.4 is fixed, let's use the latest version. As of now, install the old version for each os.
+        # if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+        #   conda install -c pytorch faiss-cpu==1.7.3
+        # elif [ "${{ matrix.os }}" = "macos-latest" ]; then
+        #   conda install -c pytorch faiss-cpu==1.7.3
+        # elif [ "${{ matrix.os }}" = "windows-latest" ]; then
+        #   conda install -c pytorch faiss-cpu==1.7.2
+        # fi
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda


### PR DESCRIPTION
faiss v1.7.4 seems to have some problem with loading mkl. The test fails with the following log:

```
 ______________________ ERROR collecting tests/test_pq.py _______________________
ImportError while importing test module '/home/runner/work/nanopq/nanopq/tests/test_pq.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/share/miniconda3/envs/test/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_pq.py:7: in <module>
    import nanopq
nanopq/__init__.py:4: in <module>
    from .convert_faiss import faiss_to_nanopq, nanopq_to_faiss
nanopq/convert_faiss.py:8: in <module>
    import faiss
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/faiss/__init__.py:16: in <module>
    from .loader import *
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/faiss/loader.py:65: in <module>
    from .swigfaiss import *
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/faiss/swigfaiss.py:13: in <module>
    from . import _swigfaiss
E   ImportError: libmkl_intel_lp64.so.1: cannot open shared object file: No such file or directory
```

Let's wait for the bug of v1.7.4 will be fixed. As for now, let's use the old version (v1.7.3). It seems [there are no windows/mac builds for 1.7.3](https://anaconda.org/pytorch/faiss-cpu/files?channel=main), so the tests for win/mac fail.
