### PR TITLE
Follow up PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       shell: bash -l {0}    # to activate conda
       run: |
         pip install pytest
-        python setup.py install
+        pip install   # In stall this library
         conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.
         
     - name: Test with pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       shell: bash -l {0}    # to activate conda
       run: |
         pip install pytest
-        pip install   # In stall this library
+        pip install .   # In stall this library
         conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.
         
     - name: Test with pytest

--- a/nanopq/opq.py
+++ b/nanopq/opq.py
@@ -26,8 +26,8 @@ class OPQ(object):
 
     """
 
-    def __init__(self, M, Ks=256, metric='l2', minit='points', verbose=True):
-        self.pq = PQ(M, Ks, metric=metric, minit=minit, verbose=verbose)
+    def __init__(self, M, Ks=256, metric='l2', verbose=True):
+        self.pq = PQ(M, Ks, metric=metric, verbose=verbose)
         self.R = None
 
     def __eq__(self, other):
@@ -117,7 +117,7 @@ class OPQ(object):
         R = R.astype(dtype=np.float32)
         return R
 
-    def fit(self, vecs, parametric_init=False, pq_iter=20, rotation_iter=10, seed=123):
+    def fit(self, vecs, parametric_init=False, pq_iter=20, rotation_iter=10, seed=123, minit='points'):
         """Given training vectors, this function alternatively trains
         (a) codewords and (b) a rotation matrix.
         The procedure of training codewords is same as :func:`PQ.fit`.
@@ -136,6 +136,7 @@ class OPQ(object):
             pq_iter (int): The number of iteration for k-means
             rotation_iter (int): The number of iteration for learning rotation
             seed (int): The seed for random process
+            minit (str): The method for initialization of centroids for k-means (either 'random', '++', 'points', 'matrix')
 
         Returns:
             object: self
@@ -158,10 +159,10 @@ class OPQ(object):
             pq_tmp = PQ(M=self.M, Ks=self.Ks, verbose=self.verbose)
             if i == rotation_iter - 1:
                 # In the final loop, run the full training
-                pq_tmp.fit(X, iter=pq_iter, seed=seed)
+                pq_tmp.fit(X, iter=pq_iter, seed=seed, minit=minit)
             else:
                 # During the training for OPQ, just run one-pass (iter=1) PQ training
-                pq_tmp.fit(X, iter=1, seed=seed)
+                pq_tmp.fit(X, iter=1, seed=seed, minit=minit)
 
             # (b) Update a rotation matrix R
             X_ = pq_tmp.decode(pq_tmp.encode(X))

--- a/nanopq/opq.py
+++ b/nanopq/opq.py
@@ -26,7 +26,7 @@ class OPQ(object):
 
     """
 
-    def __init__(self, M, Ks=256, metric='l2', minit='random', verbose=True):
+    def __init__(self, M, Ks=256, metric='l2', minit='points', verbose=True):
         self.pq = PQ(M, Ks, metric=metric, minit=minit, verbose=verbose)
         self.R = None
 

--- a/tests/test_pq.py
+++ b/tests/test_pq.py
@@ -31,6 +31,7 @@ class TestSuite(unittest.TestCase):
         pq2 = nanopq.PQ(M=M, Ks=Ks).fit(X)  # Can be called as a chain
         self.assertTrue(np.allclose(pq.codewords, pq2.codewords))
 
+
     def test_eq(self):
         import copy
 

--- a/tests/test_pq.py
+++ b/tests/test_pq.py
@@ -114,24 +114,6 @@ class TestSuite(unittest.TestCase):
         self.assertTrue((dist1 == dist2).all())
         self.assertTrue(abs(np.mean(np.matmul(X, q[:, None]).squeeze() - dist1)) < 1e-7)
         
-    def test_angular(self):
-        N, D, M, Ks = 100, 12, 4, 10
-        X = np.random.random((N, D)).astype(np.float32)
-        X[np.linalg.norm(X, axis=1) == 0] = 1.0 / np.sqrt(X.shape[1])
-        X /= np.linalg.norm(X, ord=2, axis=-1)[:, None]
-        pq = nanopq.PQ(M=M, Ks=Ks, metric='angular')
-        pq.fit(X)
-        X_ = pq.encode(X)
-        q = X[13]
-        dist1 = pq.dtable(q).adist(X_)
-        dtable = np.empty((pq.M, pq.Ks), dtype=np.float32)
-        for m in range(pq.M):
-            query_sub = q[m * pq.Ds : (m + 1) * pq.Ds]
-            dtable[m, :] = np.matmul(pq.codewords[m], query_sub[None, :].T).sum(axis=-1)
-        dist2 = 1 - np.sum(dtable[range(M), X_], axis=1) 
-        self.assertTrue((dist1 == dist2).all())
-        self.assertTrue(abs(np.mean((1-np.matmul(X, q[:, None]) / (np.linalg.norm(q) * np.linalg.norm(X, ord=2, axis=-1))) - dist1)) < 1e-7)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up PR for #24 
- For now, let me remove the option for angular. As faiss doesn't have the angular option, converting to faiss may cause some problems.
- Let's keep the original initialization option for kmeans: `minit='points'`
- If I understand correctly, `q @ x.T` is fine for IP.
- `D` is not used for DistanceTable
- Change the position of `minit` to the fit function as `minit` is used only for training
- `python setup.py install` is deprecated. Use `pip install .` instead.