### PR TITLE
Fix a bug to use faiss

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}    # to activate conda
       run: |
+        python -m pip install --upgrade pip
         pip install pytest
         pip install .   # Install this library
         conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}    # to activate conda
       run: |
-        python -m pip install --upgrade pip
         pip install pytest
         pip install .   # Install this library
         conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.

--- a/nanopq/convert_faiss.py
+++ b/nanopq/convert_faiss.py
@@ -6,17 +6,18 @@ if spec is None:
     pass  # If faiss hasn't been installed. Just skip
 else:
     import faiss
+    faiss_metric_map = {
+        "l2": faiss.METRIC_L2,
+        "dot": faiss.METRIC_INNER_PRODUCT,
+        "angular": faiss.METRIC_INNER_PRODUCT,
+    }
+
 
 import numpy as np
 
 from .opq import OPQ
 from .pq import PQ
 
-faiss_metric_map = {
-    "l2": faiss.METRIC_L2,
-    "dot": faiss.METRIC_INNER_PRODUCT,
-    "angular": faiss.METRIC_INNER_PRODUCT,
-}
 
 
 def nanopq_to_faiss(pq_nanopq):


### PR DESCRIPTION
Even when faiss is not installed, `faiss.METRIC_L2` is always called, causing the error. This PR fixes it.

Before this PR:
```console
$ make test 

...

tests/test_pq.py:7: in <module>
    import nanopq
nanopq/__init__.py:4: in <module>
    from .convert_faiss import faiss_to_nanopq, nanopq_to_faiss
nanopq/convert_faiss.py:16: in <module>
    "l2": faiss.METRIC_L2,
E   NameError: name 'faiss' is not defined
============================================================ short test summary info =============================================================
ERROR tests/test_convert_faiss.py - NameError: name 'faiss' is not defined
ERROR tests/test_opq.py - NameError: name 'faiss' is not defined
ERROR tests/test_pq.py - NameError: name 'faiss' is not defined
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=============================================================== 3 errors in 0.51s ================================================================
make: *** [Makefile:4: test] Error 2
```

With this PR:
```console 
$ make test

...

tests/test_opq.py .....                                                                                                                                                                                               [ 41%]
tests/test_pq.py .......                                                                                                                                                                                              [100%]

=============================================================================================== 12 passed, 1 skipped in 0.28s ===============================================================================================
```