### PR TITLE
Updated CI by testing various Python versions with the latest faiss

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"] #, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}    # to activate conda
       run: |
+        python -m pip install --upgrade pip
         pip install pytest
         pip install .   # Install this library
         conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
+        python-version: [3.8, 3.9, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
 
     steps:
     - name: Checkout
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install .   # Install this library
-        conda install -c pytorch "faiss-cpu<1.7.4"  # 1.7.4 doesn't work as of May 2023. Should be updated some day.
+        conda install -c pytorch faiss-cpu=1.7.4 mkl=2021 blas=1.0=mkl
         
     - name: Test with pytest
       shell: bash -l {0}   # to activate conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
+        python-version: [3.8] #, 3.9, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9] #, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
+        python-version: ["3.8", "3.9", "3.10"] #, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8] #, 3.9, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
+        python-version: [3.8, 3.9] #, 3.10]  #[3.8, 3.9, 3.10] # The test fails for py 3.10 as of April 2023. Should be updated some day.
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Now CI supports
- faiss 1.7.4
- Python 3.8, 3.9, and 3.10