### PR TITLE
Build read-the-docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Dependencies required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 faiss-cpu    # To render docs easily, use un-official pypi version of faiss
+sphinx-rtd-theme


### PR DESCRIPTION
Now we need `.readthedocs.yaml` to build the doc

solve #36 